### PR TITLE
rapidjson: fixed isnan definition with modern compilers (xenial g++ 5.3.1)

### DIFF
--- a/include/handystats/rapidjson/writer.h
+++ b/include/handystats/rapidjson/writer.h
@@ -6,7 +6,7 @@
 #include "internal/strfunc.h"
 #include <cstdio>	// snprintf() or _sprintf_s()
 #include <new>		// placement new
-#include <cmath>	// isnan(double)
+#include <cmath>	// std::isnan(double)
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -164,7 +164,7 @@ protected:
 
 	//! \todo Optimization with custom double-to-string converter.
 	void WriteDouble(double d) {
-		if (isnan(d)) {
+		if (std::isnan(d)) {
 			d = 0;
 		}
 		char buffer[100];


### PR DESCRIPTION
N.B. rapidjson also requires `dos2unix` run
